### PR TITLE
install "bash" package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN bnl-apk-install-download-deps                                               
     && apk del download-deps build-deps ruby-deps                                               \
     && rm -r /usr/local/src/ruby-${RUBY_VERSION}*
 
-RUN apk-install socat=1.7.3.0-r0
+RUN apk-install socat=1.7.3.0-r0 bash=4.3.30-r0
 
 RUN mkdir -p /opt/rubies/ruby-${RUBY_VERSION}/etc \
     && echo 'gem: --no-document' > /opt/rubies/ruby-${RUBY_VERSION}/etc/gemrc

--- a/spec/ruby_spec.rb
+++ b/spec/ruby_spec.rb
@@ -19,6 +19,10 @@ describe RSpec.configuration.docker_image_name do
     its(:exit_status) { is_expected.to eq 0 }
   end
 
+  describe command('command -v bash') do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
   describe command('command -v ruby-install') do
     its(:exit_status) { is_expected.to eq 0 }
   end


### PR DESCRIPTION
Too many tools (including Drone) expect bash to be installed.